### PR TITLE
Downgrade crypto-js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@terra-money/terra.js": "^1.3.6",
-    "@types/crypto-js": "^4.0.1",
-    "crypto-js": "^4.0.0"
+    "@types/crypto-js": "^3.0.0",
+    "crypto-js": "^3.3.0"
   },
   "devDependencies": {
     "@size-limit/preset-small-lib": "^4.9.1",


### PR DESCRIPTION
crypto-js ^4.0.0 was incompatible with React Native